### PR TITLE
✨ add props to card for customisation

### DIFF
--- a/docs/client/components/common/DefaultCode/Card/index.js
+++ b/docs/client/components/common/DefaultCode/Card/index.js
@@ -5,8 +5,11 @@ class Demo extends React.Component {
       <Card
         header='Card String header'
         wrapContent
+        expandedContent={
+          () => <div>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. </div>
+        }
         theme={theme}>
-        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
       </Card>
     )
   }

--- a/src/card/index.js
+++ b/src/card/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import defaultTheme from './theme.scss';
+import '../globals/fonts.scss';
 
 class Card extends React.Component {
   constructor(props) {
@@ -17,6 +18,78 @@ class Card extends React.Component {
       expanded: !prevState.expanded,
     }));
   };
+
+  renderFooter = () => {
+    const { theme, actions, footer } = this.props;
+    const { expanded } = this.state;
+
+    if (footer !== null) {
+      return (
+        <div className={classnames(theme.cardFooter)}>
+          { footer }
+        </div>
+      );
+    }
+
+    const iconProps = {
+      onClick: this.toggleCard,
+      className: classnames(
+        theme['more-icon'],
+        { [theme['less-icon']]: expanded },
+      ),
+    };
+
+    return (
+      <div className={classnames(theme.cardFooter)}>
+        <div className={theme['card-actions']}>
+          {
+            actions !== null &&
+            actions
+          }
+        </div>
+        {/* eslint-disable jsx-a11y/click-events-have-key-events */}
+        {/* eslint-disable jsx-a11y/no-static-element-interactions */}
+        <div {...iconProps} />
+      </div>
+    );
+  }
+
+  renderContent = () => {
+    const { children } = this.props;
+
+    const contentAreaProps = {
+      'aria-label': 'card-content',
+    };
+
+    return (
+      <div {...contentAreaProps}>
+        {children}
+      </div>
+    );
+  }
+
+  renderHeader = () => {
+    const { theme, header } = this.props;
+
+    const headerProps = {
+      'aria-label': 'card-header',
+      className: classnames(theme.cardHeader),
+    };
+
+    let cardHeader = null;
+    if (typeof header === 'string') {
+      cardHeader = <span>{header}</span>;
+    } else if (typeof header === 'function') {
+      cardHeader = header();
+    }
+
+    return (
+      <div {...headerProps}>
+        {cardHeader}
+      </div>
+    );
+  }
+
   render() {
     const {
       children,
@@ -25,48 +98,39 @@ class Card extends React.Component {
       wrapContent,
       elevation,
       noPadding,
-      header,
+      expandedContent,
       ...other
     } = this.props;
 
     const { expanded } = this.state;
-    const classes = classnames(
-      theme.card,
-      theme[`elevation-${elevation}`],
-      {
-        [theme.wrapContent]: wrapContent,
-        [theme.noPadding]: noPadding,
-      },
-      className,
-    );
-    const headerClass = classnames(theme.cardHeader);
-
-    let cardHeader;
-    if (typeof header === 'string') {
-      cardHeader = <span>{header}</span>;
-    } else if (typeof header === 'function') {
-      cardHeader = header();
+    let HiddenContent;
+    if (typeof expandedContent === 'function') {
+      HiddenContent = expandedContent;
+    } else {
+      HiddenContent = () => expandedContent;
     }
 
+    const rootProps = {
+      'data-react-toolbox': 'card',
+      className: classnames(
+        theme.card,
+        theme[`elevation-${elevation}`],
+        {
+          [theme.wrapContent]: wrapContent,
+          [theme.noPadding]: noPadding,
+        },
+        className,
+      ),
+      ...other,
+    };
+
     return (
-      <div data-react-toolbox="card" className={classes} {...other}>
-        <div className={headerClass} aria-label="card-header">
-          {cardHeader}
-        </div>
-        <div
-          className={classnames({
-            [`${theme.collapsed}`]: !expanded,
-          })}
-        >
-          {children}
-        </div>
-        <div className={classnames(theme.cardFooter)}>
-          {/* eslint-disable jsx-a11y/click-events-have-key-events */}
-          {/* eslint-disable jsx-a11y/no-static-element-interactions */}
-          <span onClick={this.toggleCard}>
-            {expanded ? 'Collapse' : 'Expand'}
-          </span>
-        </div>
+      <div {...rootProps}>
+        { this.renderHeader() }
+        { this.renderContent() }
+        { this.renderFooter() }
+        { (expandedContent !== null && expanded)
+            && <HiddenContent /> }
       </div>
     );
   }
@@ -83,6 +147,12 @@ Card.propTypes = {
   noPadding: PropTypes.bool,
   elevation: PropTypes.oneOf(['low', 'medium', 'high']),
   header: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  expandedContent: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.node,
+  ]),
+  actions: PropTypes.node,
+  footer: PropTypes.node,
 };
 
 Card.defaultProps = {
@@ -92,6 +162,9 @@ Card.defaultProps = {
   wrapContent: false,
   noPadding: false,
   header: null,
+  expandedContent: null,
+  actions: null,
+  footer: null,
 };
 
 export default themr('CBCard', defaultTheme)(Card);

--- a/src/card/theme.scss
+++ b/src/card/theme.scss
@@ -1,6 +1,7 @@
 @import '../globals/theme';
 
 :local(.card) {
+  display: flex;
   box-sizing: border-box;
   background: $original-white;
   border-radius: 3px;
@@ -45,22 +46,48 @@
 :local(.cardFooter) {
   width: 100%;
   margin-top: 2%;
+  display: flex;
+  justify-content: space-between;
   box-sizing: border-box;
   padding: 1%;
   font-size: 0.8rem;
+}
 
-  span {
-    float: right;
+:local(.card-actions) {
+  float: left;
+  align-self: center;
+  height: 100%;
+  width: 50%;
+}
+
+:local(.more-icon) {
+  height: 20px;
+  width: 20px;
+  position: relative;
+  border-radius: 50%;
+  box-sizing: border-box;
+  padding: 1em;
+  &:hover {
     cursor: pointer;
-    font-weight: 700;
-    color: #2c87d7;
+  }
+  &::after {
+    position: absolute;
+    content: '';
+    display: block;
+    border-left: 2px solid #454a4f;
+    border-bottom: 2px solid #454a4f;
+    height: 8px;
+    width: 8px;
+    top: 0.4em;
+    left: 30%;
+    transform: rotate(-45deg);
+    transition: 0.3s ease-in-out;
   }
 }
 
-:local(.collapsed) {
-  transition: 1s ease-in-out;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 7;
-  -webkit-box-orient: vertical;
+:local(.less-icon) {
+  &::after {
+    top: 0.7em;
+    transform: rotate(135deg);
+  }
 }


### PR DESCRIPTION
add options for adding card actions ( at bottom left side of the card ), add `expandedContent` prop to add content that is visible only on expanding card, add optional custom footer element, main content ( always visible ) can be passed as children.