### PR TITLE
⬆️  (root, docs)-update react-css-themr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,16 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ=="
     },
+    "@friendsofreactjs/react-css-themr": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@friendsofreactjs/react-css-themr/-/react-css-themr-3.4.0.tgz",
+      "integrity": "sha512-ebGxDHu8sjmYcULY9XwUViJp32q2+fO7k+SwnZ/o8gW6KlLgezEVbTzY8snD3osTFp1iP/2VUegHlP6paZ8EDg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.1.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.6.2"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -4691,9 +4701,12 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
+      "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+      "requires": {
+        "react-is": "^16.3.2"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -9812,11 +9825,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
       "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg=="
     },
-    "react-css-themr": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-css-themr/-/react-css-themr-2.1.2.tgz",
-      "integrity": "sha1-4BdRTkccIy9Dp1SlW0nYH69dr7g="
-    },
     "react-dom": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.1.tgz",
@@ -9825,8 +9833,7 @@
     "react-is": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
-      "dev": true
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
     },
     "react-live": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "@friendsofreactjs/react-css-themr": "^3.4.0",
     "babel-eslint": "^8.2.3",
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
@@ -80,7 +81,6 @@
     "prop-types": "^15.6.2",
     "ramda": "^0.25.0",
     "react": "^16.3.2",
-    "react-css-themr": "^2.1.2",
     "react-dom": "^16.3.2",
     "react-live": "^1.11.0",
     "sinon": "^6.3.4"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -48,7 +48,7 @@ module.exports = {
   },
   resolve: {
     alias: {
-      'react-css-themr': '@friendsofreactjs/react-css-themr',
+      'react-css-themr': path.resolve(__dirname, './node_modules/@friendsofreactjs/react-css-themr'),
     },
   },
   plugins: [

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -46,6 +46,11 @@ module.exports = {
       },
     ],
   },
+  resolve: {
+    alias: {
+      'react-css-themr': '@friendsofreactjs/react-css-themr',
+    },
+  },
   plugins: [
     htmlWebpackPlugin,
     // new BundleAnalyzerPlugin(),


### PR DESCRIPTION
Switch to maintained fork for react-css-themr since the original repo is no longer maintained and will be no longer usable in v17. [Link to maintained fork](https://github.com/FriendsOfReactJS/react-css-themr)
