### PR TITLE
🐛  (gatsby-config)-remove camel-casing of sass variables

### DIFF
--- a/doc/gatsby-config.js
+++ b/doc/gatsby-config.js
@@ -4,7 +4,14 @@ module.exports = {
   },
   plugins: [
     'gatsby-plugin-react-helmet',
-    'gatsby-plugin-sass',
+    {
+      resolve: `gatsby-plugin-sass`,
+      options: {
+        cssLoaderOptions: {
+          camelCase: false,
+        },
+      },
+    },
     {
       resolve: `gatsby-plugin-manifest`,
       options: {


### PR DESCRIPTION
This should solve the issues with default styles / themes.