### PR TITLE
🐛 Fix sidebar height bug

### DIFF
--- a/doc/src/components/WithComponentsBar/styles.scss
+++ b/doc/src/components/WithComponentsBar/styles.scss
@@ -154,6 +154,7 @@
 
 :local(.drawer) {
     padding: 0;
+    height: calc(100% - 100px);
     @media only screen and (min-width: 992px) {
         left: 0 !important;
     }


### PR DESCRIPTION
 #225

### Status :
Ready
##

### Description :
The last element of the sidebar is not accessible. Because the sidebar occupies 100vh but has a top of 100px which results in the content to overflow outside view.
##
### Related Issues :
#225 

