### PR TITLE
fix: remove isomorphic style loader and use style loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "eslint-plugin-react": "^7.7.0",
     "file-loader": "^3.0.1",
     "glob": "^7.1.3",
-    "isomorphic-style-loader": "^5.0.1",
     "jsdom": "13.1.0",
     "jsdom-global": "3.0.2",
     "mini-css-extract-plugin": "^0.5.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -25,7 +25,7 @@ const sassLoader = prod
   : `${require.resolve('sass-loader')}?sourceMap`;
 
 const styleLoader = [
-  'isomorphic-style-loader',
+  'style-loader',
   cssLoader,
   sassLoader,
 ];


### PR DESCRIPTION
### Status :
Ready

##

### Description :
using isomorphic style loader is currently breaking the components style. For now, we can use
style-loader to continue development and later fix the window not found issue for gatsby sites ( SSR
in general )

##

## Todos
- [x] Tests