### PR TITLE
Replace uglifyjs-webpack-plugin with terser-webpack-plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "semantic-release": "^15.13.1",
     "sinon": "^7.2.2",
     "style-loader": "^0.21.0",
-    "uglifyjs-webpack-plugin": "^2.1.0",
+    "terser-webpack-plugin": "^1.3.0",
     "webpack": "^4.28.2",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const glob = require('glob');
 
@@ -72,7 +72,7 @@ module.exports = {
   },
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
+      new TerserPlugin({
         cache: true,
         parallel: true,
         sourceMap: true,


### PR DESCRIPTION
### Status :
Ready
##

### Description :
Build fails.
ES6 isn't supported by `uglify-webpack-plugin`.

Use [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin). 

##
### Related Issues :
Ref: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/362
